### PR TITLE
Refactors

### DIFF
--- a/lib/rspec-rcv.rb
+++ b/lib/rspec-rcv.rb
@@ -27,6 +27,6 @@ module RSpecRcv
   end
 
   def config(overrides=nil)
-    @configuration.opts(overrides)
+    configuration.opts(overrides)
   end
 end

--- a/lib/rspec-rcv/handler.rb
+++ b/lib/rspec-rcv/handler.rb
@@ -63,6 +63,7 @@ module RSpecRcv
       diff.to_s.each_line do |line|
         key = line.split("\"")[1]
         next if opts.fetch(:ignore_keys, []).include?(key)
+        next if key.nil?
 
         if line.start_with?("-")
           removed << key
@@ -76,8 +77,8 @@ Existing data will be overwritten. Turn off this feature with fail_on_changed_ou
 
 #{diff}
 
-The following keys were added: #{added}
-The following keys were removed: #{removed}
+The following keys were added: #{added.uniq}
+The following keys were removed: #{removed.uniq}
       EOF
     end
   end

--- a/lib/rspec-rcv/handler.rb
+++ b/lib/rspec-rcv/handler.rb
@@ -9,7 +9,7 @@ module RSpecRcv
     end
 
     def call
-      return if existing_data && existing_data["file"] == file_path && existing_data["data"] == data
+      return :no_change if existing_data && existing_data["file"] == file_path && existing_data["data"] == data
 
       output = { recorded_at: Time.now, file: file_path, data: data }
       output = opts[:codec].export_with(output) + "\n"
@@ -22,13 +22,15 @@ module RSpecRcv
           raise RSpecRcv::DataChangedError.new("Existing data will be overwritten. Turn off this feature with fail_on_changed_output=false\n\n#{diff}")
         end
 
-        return if eq
+        return :same if eq
       end
 
       FileUtils.mkdir_p(File.dirname(path))
       File.open(path, 'w') do |file|
         file.write(output)
       end
+
+      return :to_disk
     end
 
     private

--- a/lib/rspec-rcv/handler.rb
+++ b/lib/rspec-rcv/handler.rb
@@ -62,6 +62,7 @@ module RSpecRcv
       added = []
       diff.to_s.each_line do |line|
         key = line.split("\"")[1]
+        next if opts.fetch(:ignore_keys, []).include?(key)
 
         if line.start_with?("-")
           removed << key

--- a/lib/rspec-rcv/version.rb
+++ b/lib/rspec-rcv/version.rb
@@ -1,3 +1,3 @@
 module RSpecRcv
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -56,6 +56,20 @@ RSpec.describe RSpecRcv::Handler do
         end
       end
 
+      context "with ignored keys" do
+        let!(:metadata) { { fixture: file_path, ignore_keys: ["key", "ignored"] } }
+        let!(:other_data) { Proc.new { { "other" => "value", "ignored" => "value" } }}
+
+        it "doesn't output ignored keys" do
+          expect {
+            subject.call
+          }.to raise_error do |error|
+            expect(error.message).to include("The following keys were added: []")
+            expect(error.message).to include("The following keys were removed: [\"other\"]")
+          end
+        end
+      end
+
       context "when fail_on_changed_output=false" do
         let!(:metadata) { { fixture: file_path, fail_on_changed_output: false } }
 

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+RSpec.describe RSpecRcv::Handler do
+  let!(:data) { Proc.new { { "key" => "value" } } } # Hash rocket syntax because JSON read from disk is string=>string
+  let!(:file_path) { "spec/tmp/test.json" }
+  let!(:metadata) { { fixture: file_path } }
+  let(:parsed_json) { JSON.parse(File.read(file_path)) }
+
+  subject { RSpecRcv::Handler.new("spec/handler_spec.rb", data, metadata: metadata) }
+
+  after(:each) { FileUtils.rm_rf("spec/tmp") }
+
+  context "without an existing file" do
+    it "creates a new file" do
+      expect {
+        expect(subject.call).to eq(:to_disk)
+      }.to change{ File.exists?(file_path) }.from(false).to(true)
+    end
+
+    it "puts the correct fields on disk" do
+      subject.call
+      expect(parsed_json.keys).to eq(["recorded_at", "file", "data"])
+      expect(Time.parse(parsed_json["recorded_at"])).to be_within(2).of(Time.now)
+      expect(parsed_json["file"]).to eq("spec/handler_spec.rb")
+      expect(parsed_json["data"]).to eq({ "key" => "value"})
+    end
+  end
+
+  context "with an existing file" do
+    let!(:other_data) { Proc.new { { "key" => "value" } }}
+    before(:each) {
+      RSpecRcv::Handler.new("spec/handler_spec.rb", other_data, metadata: metadata).call
+    }
+
+    context "that has the same data" do
+      it "doesn't do anything" do
+        expect(subject.call).to eq(:no_change)
+      end
+    end
+
+    context "that has different data" do
+      let!(:other_data) { Proc.new { { "other" => "value" } }}
+
+      it "raises RSpecRcv::DataChangedError" do
+        expect {
+          subject.call
+        }.to raise_error(RSpecRcv::DataChangedError)
+      end
+
+      context "when fail_on_changed_output=false" do
+        let!(:metadata) { { fixture: file_path, fail_on_changed_output: false } }
+
+        it "doesn't raise an error" do
+          expect {
+            subject.call
+          }.not_to raise_error
+        end
+
+        it "writes to disk" do
+          expect {
+            expect(subject.call).to eq(:to_disk)
+          }.to change{ File.read(file_path) }
+
+          expect(parsed_json["data"]).to eq({ "key" => "value" })
+        end
+      end
+    end
+  end
+end

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -47,6 +47,15 @@ RSpec.describe RSpecRcv::Handler do
         }.to raise_error(RSpecRcv::DataChangedError)
       end
 
+      it "outputs the list of keys which changed" do
+        expect {
+          subject.call
+        }.to raise_error do |error|
+          expect(error.message).to include("The following keys were added: [\"key\"]")
+          expect(error.message).to include("The following keys were removed: [\"other\"]")
+        end
+      end
+
       context "when fail_on_changed_output=false" do
         let!(:metadata) { { fixture: file_path, fail_on_changed_output: false } }
 

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -56,6 +56,19 @@ RSpec.describe RSpecRcv::Handler do
         end
       end
 
+      context "with duplicated keys" do
+        let!(:other_data) { Proc.new { { "duplicated" => "value", "nested" => { "duplicated" => true } } }}
+
+        it "only includes the key once" do
+          expect {
+            subject.call
+          }.to raise_error do |error|
+            expect(error.message).to include("The following keys were added: [\"key\"]")
+            expect(error.message).to include("The following keys were removed: [\"duplicated\", \"nested\"]")
+          end
+        end
+      end
+
       context "with ignored keys" do
         let!(:metadata) { { fixture: file_path, ignore_keys: ["key", "ignored"] } }
         let!(:other_data) { Proc.new { { "other" => "value", "ignored" => "value" } }}


### PR DESCRIPTION
This changes the diff to include

```
Existing data will be overwritten. Turn off this feature with fail_on_changed_output=false

#{diff}

The following keys were added: #{added.uniq}
The following keys were removed: #{removed.uniq}
```

Previously, it was:

```
Existing data will be overwritten. Turn off this feature with fail_on_changed_output=false

#{diff}
```
