### PR TITLE
Refactor

### DIFF
--- a/lib/rspec-rcv/handler.rb
+++ b/lib/rspec-rcv/handler.rb
@@ -59,7 +59,6 @@ module RSpecRcv
 
     def raise_error!(output, json_compare_output)
       diff = Diffy::Diff.new(existing_file, output).to_s
-      data_index = diff.lines.find_index{ |line| line =~ /"data":/ } # keys before data are un-important
 
       removed = json_compare_output.fetch(:remove, {}).keys
       added = json_compare_output.fetch(:append, {}).keys
@@ -70,9 +69,9 @@ Existing data will be overwritten. Turn off this feature with fail_on_changed_ou
 
 #{diff}
 
-The following keys were added: #{added.uniq}
-The following keys were removed: #{removed.uniq}
-The following keys were updated: #{updated.uniq}
+The following keys were added: #{added.uniq.map(&:to_s)}
+The following keys were removed: #{removed.uniq.map(&:to_s)}
+The following keys were updated: #{updated.uniq.map(&:to_s)}
 
 This fixture is located at #{path}
       EOF

--- a/lib/rspec-rcv/handler.rb
+++ b/lib/rspec-rcv/handler.rb
@@ -114,40 +114,4 @@ class JsonOutputCombiner
 
     result
   end
-
-  class JsonOutputCombiner
-    def initialize(output)
-      @output = output
-    end
-
-    def combine
-      compact_compare_output(@output, key: "")
-    end
-
-    private
-
-    KEYS_TO_COMBINE = [:update, :append, :remove]
-
-    def combine_results(a, b)
-      KEYS_TO_COMBINE.each do |key|
-        a[key] += b[key]
-      end
-    end
-
-    def compact_compare_output(output, key:)
-      result = { update: [], append: [], remove: [] }
-      return result unless output.is_a?(Hash)
-
-      KEYS_TO_COMBINE.each do |combine_key|
-        output.fetch(combine_key, {}).each do |update_key, nested_output|
-          new_key = "#{key}#{key.empty? ? '' : '.'}#{update_key}"
-          result[combine_key] << new_key
-          nested_result = compact_compare_output(nested_output, key: new_key)
-          combine_results(result, nested_result)
-        end
-      end
-
-      result
-    end
-  end
 end

--- a/lib/rspec-rcv/handler.rb
+++ b/lib/rspec-rcv/handler.rb
@@ -1,4 +1,5 @@
 require 'diffy'
+require 'json-compare'
 
 module RSpecRcv
   class Handler
@@ -18,7 +19,7 @@ module RSpecRcv
         eq = opts[:compare_with].call(existing_data["data"], data, opts)
 
         if !eq && opts[:fail_on_changed_output]
-          raise_error!(output)
+          raise_error!(output, JsonCompare.get_diff(existing_data["data"], data, opts.fetch(:ignore_keys, [])))
         end
 
         return :same if eq
@@ -56,25 +57,13 @@ module RSpecRcv
                          end
     end
 
-    def raise_error!(output)
+    def raise_error!(output, json_compare_output)
       diff = Diffy::Diff.new(existing_file, output).to_s
       data_index = diff.lines.find_index{ |line| line =~ /"data":/ } # keys before data are un-important
 
-      removed = []
-      added = []
-
-      diff.lines[data_index..-1].each do |line|
-        key = line.split("\"")[1]
-        next if key.nil?
-        next if opts.fetch(:ignore_keys, []).include?(key.to_s)
-        next if opts.fetch(:ignore_keys, []).include?(key.to_sym)
-
-        if line.start_with?("-")
-          removed << key
-        elsif line.start_with?("+")
-          added << key
-        end
-      end
+      removed = json_compare_output.fetch(:remove, {}).keys
+      added = json_compare_output.fetch(:append, {}).keys
+      updated = json_compare_output.fetch(:update, {}).keys
 
       raise RSpecRcv::DataChangedError.new(<<-EOF)
 Existing data will be overwritten. Turn off this feature with fail_on_changed_output=false
@@ -83,6 +72,8 @@ Existing data will be overwritten. Turn off this feature with fail_on_changed_ou
 
 The following keys were added: #{added.uniq}
 The following keys were removed: #{removed.uniq}
+The following keys were updated: #{updated.uniq}
+
 This fixture is located at #{path}
       EOF
     end

--- a/rspec-rcv.gemspec
+++ b/rspec-rcv.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0.0'
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "pry"
   spec.add_runtime_dependency "rspec"
   spec.add_runtime_dependency "diffy"
+  spec.add_runtime_dependency "json-compare"
 end

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -38,6 +38,25 @@ RSpec.describe RSpecRcv::Handler do
       end
     end
 
+    context "with an array of changed values" do
+      let!(:data) { Proc.new { { "ids" => [2] } } }
+      let!(:other_data) { Proc.new { { ids: [1] } }}
+
+      it "raises RSpecRcv::DataChangedError" do
+        expect {
+          subject.call
+        }.to raise_error(RSpecRcv::DataChangedError)
+      end
+
+      it "outputs the list of keys which changed" do
+        expect {
+          subject.call
+        }.to raise_error do |error|
+          expect(error.message).to include("The following keys were updated: [\"ids\"]")
+        end
+      end
+    end
+
     context "that has different data" do
       let!(:other_data) { Proc.new { { "other" => "value" } }}
 

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe RSpecRcv::Handler do
         expect {
           subject.call
         }.to raise_error do |error|
-          expect(error.message).to include("The following keys were updated: [\"ids\"]")
+          expect(error.message).to include('The following keys were updated: ["ids", "ids.0"]')
         end
       end
     end
@@ -87,9 +87,9 @@ RSpec.describe RSpecRcv::Handler do
         expect {
           subject.call
         }.to raise_error do |error|
-          expect(error.message).to include("The following keys were added: [\"d\"]")
-          expect(error.message).to include("The following keys were removed: [\"c\"]")
-          expect(error.message).to include("The following keys were updated: [\"a\"]")
+          expect(error.message).to include('The following keys were updated: ["ids", "ids.a", "ids.b"]')
+          expect(error.message).to include('The following keys were added: ["ids.b.c"]')
+          expect(error.message).to include('The following keys were removed: ["ids.b.d"]')
         end
       end
     end

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe RSpecRcv::Handler do
   end
 
   context "with an existing file" do
-    let!(:other_data) { Proc.new { { "key" => "value" } }}
+    let!(:existing_data) { Proc.new { { "key" => "value" } }}
     before(:each) {
-      RSpecRcv::Handler.new("spec/handler_spec.rb", other_data, metadata: metadata).call
+      RSpecRcv::Handler.new("spec/handler_spec.rb", existing_data, metadata: metadata).call
     }
 
     context "that has the same data" do
@@ -40,7 +40,7 @@ RSpec.describe RSpecRcv::Handler do
 
     context "with an array of changed values" do
       let!(:data) { Proc.new { { "ids" => [2] } } }
-      let!(:other_data) { Proc.new { { ids: [1] } }}
+      let!(:existing_data) { Proc.new { { ids: [1] } }}
 
       it "raises RSpecRcv::DataChangedError" do
         expect {
@@ -57,8 +57,45 @@ RSpec.describe RSpecRcv::Handler do
       end
     end
 
+    context "with a deep hash of changed values" do
+      let!(:data) { Proc.new { {
+        "ids" => {
+          "a" => 1,
+          "b" => {
+            "c" => {
+              "d" => 2
+            }
+          }
+        }
+      } } }
+      let!(:existing_data) { Proc.new { {
+        "ids" => {
+          "a" => 2,
+          "b" => {
+            "d" => 2
+          }
+        }
+      } } }
+
+      it "raises RSpecRcv::DataChangedError" do
+        expect {
+          subject.call
+        }.to raise_error(RSpecRcv::DataChangedError)
+      end
+
+      it "outputs the list of keys which changed" do
+        expect {
+          subject.call
+        }.to raise_error do |error|
+          expect(error.message).to include("The following keys were added: [\"d\"]")
+          expect(error.message).to include("The following keys were removed: [\"c\"]")
+          expect(error.message).to include("The following keys were updated: [\"a\"]")
+        end
+      end
+    end
+
     context "that has different data" do
-      let!(:other_data) { Proc.new { { "other" => "value" } }}
+      let!(:existing_data) { Proc.new { { "other" => "value" } }}
 
       it "raises RSpecRcv::DataChangedError" do
         expect {
@@ -76,7 +113,7 @@ RSpec.describe RSpecRcv::Handler do
       end
 
       context "with duplicated keys" do
-        let!(:other_data) { Proc.new { { "duplicated" => "value", "nested" => { "duplicated" => true } } }}
+        let!(:existing_data) { Proc.new { { "duplicated" => "value", "nested" => { "duplicated" => true } } }}
 
         it "only includes the key once" do
           expect {
@@ -90,7 +127,7 @@ RSpec.describe RSpecRcv::Handler do
 
       context "with ignored keys" do
         let!(:metadata) { { fixture: file_path, ignore_keys: ["key", "ignored"] } }
-        let!(:other_data) { Proc.new { { "other" => "value", "ignored" => "value" } }}
+        let!(:existing_data) { Proc.new { { "other" => "value", "ignored" => "value" } }}
 
         it "doesn't output ignored keys" do
           expect {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
+require 'pry'
 require 'rspec-rcv'


### PR DESCRIPTION
Reverts SalesLoft/rspec-rcv#5

This provides more functionality for comparison. The Diffy comparison was brittle, but json comparer is very accurate. This allows for actual array comparison and will now give output like:

```
       The following keys were added: []
       The following keys were removed: ["previews.0.devices", "previews.1.devices", "previews.2.devices", "previews.3.devices", "previews.4.devices"]
       The following keys were updated: ["previews", "previews.0", "previews.1", "previews.2", "previews.3", "previews.4"]
```

This becomes very clear for what changed in RCV fixtures.
