### PR TITLE
Add configuration method to decide what existing data to compare

### DIFF
--- a/lib/rspec-rcv/configuration.rb
+++ b/lib/rspec-rcv/configuration.rb
@@ -9,7 +9,10 @@ module RSpecRcv
         ignore_keys: [],
         fail_on_changed_output: true,
         base_path: nil,
-        fixture: nil
+        fixture: nil,
+        parse_existing: Proc.new do |existing|
+          existing["data"]
+        end
     }
 
     def initialize

--- a/lib/rspec-rcv/configuration.rb
+++ b/lib/rspec-rcv/configuration.rb
@@ -81,5 +81,13 @@ module RSpecRcv
     def fail_on_changed_output=(val)
       @opts[:fail_on_changed_output] = val
     end
+
+    def parse_existing
+      @opts[:parse_existing]
+    end
+
+    def parse_existing=(val)
+      @opts[:parse_existing] = val
+    end
   end
 end

--- a/lib/rspec-rcv/handler.rb
+++ b/lib/rspec-rcv/handler.rb
@@ -16,7 +16,7 @@ module RSpecRcv
       output = opts[:codec].export_with(output) + "\n"
 
       if existing_data
-        existing_data_comparison = opts[:parse_existing].call(existing_data)
+        existing_data_comparison = opts.fetch(:parse_existing).call(existing_data)
         eq = opts[:compare_with].call(existing_data_comparison, data, opts)
 
         if !eq && opts[:fail_on_changed_output]

--- a/lib/rspec-rcv/handler.rb
+++ b/lib/rspec-rcv/handler.rb
@@ -16,10 +16,11 @@ module RSpecRcv
       output = opts[:codec].export_with(output) + "\n"
 
       if existing_data
-        eq = opts[:compare_with].call(existing_data["data"], data, opts)
+        existing_data_comparison = opts[:parse_existing].call(existing_data)
+        eq = opts[:compare_with].call(existing_data_comparison, data, opts)
 
         if !eq && opts[:fail_on_changed_output]
-          raise_error!(output, JsonCompare.get_diff(existing_data["data"], data, opts.fetch(:ignore_keys, [])))
+          raise_error!(output, JsonCompare.get_diff(existing_data_comparison, data, opts.fetch(:ignore_keys, [])))
         end
 
         return :same if eq

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -79,6 +79,19 @@ RSpec.describe RSpecRcv::Configuration do
     end
   end
 
+  describe "parse_existing" do
+    it "defaults to using existing data" do
+      expect(subject.parse_existing.call({"data" => {"a" => 1}})).to eq({"a" => 1})
+    end
+
+    it "can be set" do
+      subject.parse_existing = Proc.new do |existing|
+        existing
+      end
+      expect(subject.parse_existing.call({"data" => {"a" => 1}})).to eq({"data" => {"a" => 1}})
+    end
+  end
+
   describe ".reset!" do
     before(:each) {
       subject.base_path = "test"


### PR DESCRIPTION
Hello! I found this useful, don't know if it fits with your design or not. I use the codec to remove the "recorded_at" and "file" properties of the json and move the data into the json root. However, when  I do the comparison, it will always return saying there was a difference because the current code is looking for the "data" property and my json doesn't have it.

This adds a configuration method "parse_existing" to decide what existing data actually gets compared. Thanks!
